### PR TITLE
fix undefined variables x & y in function signature

### DIFF
--- a/skipped_correlation.m
+++ b/skipped_correlation.m
@@ -1,4 +1,4 @@
-function [r,t,h,outid,hboot,CI]=skipped_correlation(X,fig_flag)
+function [r,t,h,outid,hboot,CI]=skipped_correlation(x,y,fig_flag)
 
 % performs a robust correlation using pearson/spearman correlation on
 % data cleaned up for bivariate outliers - that is after finding the


### PR DESCRIPTION
Function signature did not include vars x & y, causing the function to fail with 

> Undefined function or variable 'x'.
> Error in skipped_correlation (line 58)
> if size(x,1) == 1 && size(x,2) > 1; x = x'; end